### PR TITLE
Added ASCII codes for '(' and ')'

### DIFF
--- a/vcd/reader.py
+++ b/vcd/reader.py
@@ -406,6 +406,8 @@ class _TokenizerState:
             or c == 95  # '_'
             or c == 36  # '$'
             or c == 46  # '.' not in spec, but seen in the wild
+            or c == 40  # '(' - produced by cva6 core
+            or c == 41  # ')' - produced by cva6 core
         ):
             identifier.append(c)
             c = self.advance(raise_on_eof=False)


### PR DESCRIPTION
The CVA6 (Ariane) core vcd dump produces these characters in the identifier names. Thus adding these to ensure parsing succeeds.