### PR TITLE
Upgrade requirements from Py3.6 to 3.7 due to dataclasses dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88
-target-version = ["py36"]
+target-version = ["py37"]
 skip-string-normalization = true
 exclude = '''
 (

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -32,7 +31,7 @@ classifiers =
 [options]
 include_package_data = True
 zip_safe = False
-python_requires = >= 3.6
+python_requires = >= 3.7
 packages = vcd
 
 [bdist_wheel]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,pypy3,flake8
+envlist = py37,py38,pypy3,flake8
 
 [testenv]
 deps = -rrequirements.txt


### PR DESCRIPTION
As described in issue #25, there exists a mistake between the minimal Python version required and the actual required version.
As this library requires _dataclasses_ module to work, I propose to upgrade the minimal Python version to 3.7.

