### PR TITLE
Adding 'logic' var type created by Verilator

### DIFF
--- a/vcd/common.py
+++ b/vcd/common.py
@@ -34,6 +34,7 @@ class VarType(Enum):
     wire = 'wire'
     wor = 'wor'
     string = 'string'
+    logic = 'logic'
 
     def __str__(self) -> str:
         return self.value


### PR DESCRIPTION
Verilator spat out a VCD file with the variable type 'logic'.  This one line addition allows me to read these VCD files and doesn't cause any failures in tests/*.py.  I have not inspected the code base beyond this.